### PR TITLE
Make verify return a result type for issue #2

### DIFF
--- a/__tests__/JsonWebToken_test.re
+++ b/__tests__/JsonWebToken_test.re
@@ -38,18 +38,38 @@ describe("JsonWebToken", () => {
     });
 
     test("should produce a token that can be verified", () => {
-      expect(JsonWebToken.verify(result, secret))
+      JsonWebToken.verify(result, secret)
+      |> Belt.Result.isOk
+      |> expect
       |> toBeTruthy
     });
   })
   
   describe("decode function", () => {
     test("should return a Js.Json.t with property foo on it", () => {
-        JsonWebToken.decode(result)
-        |> decodeTestPayload
-        |> (x) => x.foo
-        |> expect
-        |> toEqual("bar")
+      JsonWebToken.decode(result)
+      |> decodeTestPayload
+      |> (x) => x.foo
+      |> expect
+      |> toEqual("bar")
+    });
+  });
+
+  describe("verify function", () => {
+    test("should return a Result.Ok(Js.Json.t) with property foo on it", () => {
+      JsonWebToken.verify(result, secret)
+      -> Belt.Result.getWithDefault(Js.Json.string("bad result"))
+      |> decodeTestPayload
+      |> (x) => x.foo
+      |> expect
+      |> toEqual("bar")
+    });
+
+    test("should return an error result when verification fails", () => {
+      JsonWebToken.verify(result, `string("bad secret"))
+      |> Belt.Result.isError
+      |> expect
+      |> toBeTruthy
     });
   });
 });

--- a/src/JsonWebToken.re
+++ b/src/JsonWebToken.re
@@ -37,7 +37,7 @@ type secretObject = {
   string
 ) => Js.Json.t = "decode"
 
-[@bs.module "jsonwebtoken"] external verify : (
+[@bs.module "jsonwebtoken"] external _verify : (
   string, [@bs.unwrap][`string(string) | `buffer(Node_buffer.t) | `secret(secretObject)]
 ) => Js.Json.t = "verify"
 
@@ -112,5 +112,15 @@ let sign = (~secret: secret, ~options: option(signOptions), payload: [`json(Js.J
   switch(options) {
     | Some(option) => signWithOptions(payload, secret, encodeSignOptions(option))
     | None => signWithoutOptions(payload, secret);
+  }
+};
+
+let verify = (token: string, secret: secret): Belt.Result.t(Js.Json.t, string) => {
+  try(Belt.Result.Ok(_verify(token, secret))){
+    | Js.Exn.Error(e) => 
+      switch(Js.Exn.message(e)) {
+        | Some(message) => Belt.Result.Error(message)
+        | None          => Belt.Result.Error("An unknown error occured") 
+      }
   }
 };


### PR DESCRIPTION
Verify function now returns a Belt.Result.t type and catches the exception that jsonwebtoken throws if verify is not successful